### PR TITLE
Basic, grid-free layout

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,20 +1,25 @@
 <template>
   <div id="app">
-    <div class="container">
-      <header>🤓📚</header>
+    <header>
+      <h1>🤓📚</h1>
+    </header>
 
-      <main>
-        <div class="loader" v-if="this.loading"><loader /></div>
-        <template v-else>
-          <div class="errors" v-if="this.hasErrors">😳😅</div>
-          <books v-else :books="books" />
-        </template>
-      </main>
+    <main>
+      <template v-if="this.loading || this.hasErrors">
+        <loader v-if="this.loading" />
+        <div v-if="this.hasErrors"><p>😳😅</p></div>
+      </template>
+      <template v-else>
+        <books v-if="this.hasBooks" :books="books" />
+        <div v-else><p>There are no books. 😞</p></div>
+      </template>
+    </main>
 
-      <footer>
+    <footer>
+      <p>
         &ldquo;{{ this.quote.body }}&rdquo; &mdash; {{ this.quote.author }}
-      </footer>
-    </div>
+      </p>
+    </footer>
   </div>
 </template>
 
@@ -42,6 +47,9 @@
     computed: {
       hasErrors() {
         return this.errors.length > 0
+      },
+      hasBooks() {
+        return this.books.length > 0
       }
     },
     methods: {
@@ -59,42 +67,27 @@
 
 <style lang="scss" scoped>
   #app {
-    margin: 0 auto;
-  }
-
-  .container {
     min-height: 100vh;
-    display: grid;
-    grid-template-columns: 100%;
-    grid-template-rows: auto 1fr auto;
-    grid-template-areas:
-      "header"
-      "main"
-      "footer";
-    justify-items: center;
-    align-items: stretch;
-
-    .loader, .errors {
-      padding-top: 15vh;
-    }
+    display: flex;
+    flex-direction: column;
   }
 
   header {
-    grid-area: header;
-    width: 100%;
     background: hsl(0, 0%, 10%);
-    padding: 0.3em;
-    font-size: 1.5em;
+    padding: 0.5em;
+    margin-bottom: 0.5em;
+
+    h1 {
+      margin: 0;
+    }
   }
 
   main {
-    grid-area: main;
-    max-width: 1000px;
+    flex: 1;
+    text-align: center;
   }
 
   footer {
-    grid-area: footer;
-    width: 100%;
     background: hsl(0, 0%, 20%);
     color: hsl(360, 100%, 100%);
     padding: 1em;
@@ -102,5 +95,6 @@
     font-size: 0.7em;
     font-weight: 300;
     font-style: italic;
+    margin-top: 0.5em;
   }
 </style>

--- a/app/javascript/components/__tests__/book.spec.js
+++ b/app/javascript/components/__tests__/book.spec.js
@@ -1,0 +1,30 @@
+import { shallow } from '@vue/test-utils'
+import Book from '@/components/book.vue'
+
+describe('Book', () => {
+  describe('hasBookCover', () => {
+    it('uses the book cover image if a proper one is available', () => {
+      const wrapper = shallow(Book, {
+        propsData: {
+          book: {
+            image_url: 'https://images.gr-assets.com/books/1487215696l/29214420.jpg'
+          }
+        }
+      })
+
+      expect(wrapper.vm.hasBookCover).toEqual(true)
+    })
+
+    it('does not consider the Goodreads no-book image to be available', () => {
+      const wrapper = shallow(Book, {
+        propsData: {
+          book: {
+            image_url: 'https://s.gr-assets.com/assets/nophoto/book/111x148-bcc042a9c91a29c1d680899eff700a03.png'
+          }
+        }
+      })
+
+      expect(wrapper.vm.hasBookCover).toEqual(false)
+    })
+  })
+})

--- a/app/javascript/components/__tests__/books.spec.js
+++ b/app/javascript/components/__tests__/books.spec.js
@@ -2,19 +2,6 @@ import { shallow } from '@vue/test-utils'
 import Books from '@/components/books.vue'
 
 describe('Books', () => {
-  it('renders the no-books message when not given props', () => {
-    const wrapper = shallow(Books)
-    expect(wrapper.find('.no-books').exists()).toBeTruthy()
-    expect(wrapper.text()).toBe("There are no books. 😞")
-  })
-
-  it('renders the no-books message when there are no books in props', () => {
-    const wrapper = shallow(Books, {
-      propsData: { books: [] }
-    })
-    expect(wrapper.text()).toBe("There are no books. 😞")
-  })
-
   describe('sorting methods', () => {
     const books = [
       {title: 'A', average_rating: '4.12', year: '2008'},

--- a/app/javascript/components/book.vue
+++ b/app/javascript/components/book.vue
@@ -1,20 +1,24 @@
 <template>
   <div class="book">
-    <a :href="bookObj.link" target="_blank">
-      <span class="link"></span>
-    </a>
-    <figure class="cover">
-      <img :src="bookObj.image_url" :alt="this.bookCoverAltText" />
-    </figure>
-    <div class="info">
-      <div class="average-rating">
-        <star-rating :rating="bookObj.average_rating" />
-        <div class="rating">
-          {{ bookObj.average_rating }}
+    <a :href="book.link" target="_blank">
+      <figure class="cover">
+        <img v-if="this.hasBookCover" :src="book.image_url" :alt="this.bookCoverAltText" />
+        <div v-else class="text-cover">
+          <h5>{{ this.book.title }}</h5>
+          <h6>{{ this.book.author}}</h6>
+        </div>
+      </figure>
+      <div class="info">
+        <div class="index">{{ index | humanizeIndex }}</div>
+        <div class="details">
+          <div class="average-rating">
+            <star-rating :rating="book.average_rating" />
+            <div>{{ book.average_rating }}</div>
+          </div>
+          <div class="year">[{{ book.year }}]</div>
         </div>
       </div>
-      <div class="year">[{{ bookObj.year }}]</div>
-    </div>
+    </a>
   </div>
 </template>
 
@@ -23,12 +27,21 @@
 
   export default {
     props: {
-      bookObj: { type: Object }
+      book: { type: Object },
+      index: { type: Number }
     },
     components: { StarRating },
     computed: {
       bookCoverAltText() {
-        return `${this.bookObj.title} | ${this.bookObj.author}`
+        return `${this.book.title} | ${this.book.author}`
+      },
+      hasBookCover() {
+        return !this.book.image_url.match('/nophoto/')
+      }
+    },
+    filters: {
+      humanizeIndex(index) {
+        return index + 1
       }
     }
   }
@@ -37,47 +50,84 @@
 <style lang="scss" scoped>
   .book {
     background: hsl(360, 100%, 100%);
-    position: relative;
-    width: 320px;
-    height: 280px;
-    max-width: 90vw;
-    overflow: hidden;
     border: 1px solid hsl(0, 0%, 80%);
+    margin-bottom: 15px;
+    height: 240px;
+    width: 300px;
 
     &:hover {
       box-shadow: 3px 3px 8px hsl(0, 0%, 70%);
     }
 
-    span.link {
-      position: absolute;
-      top: 0;
-      left: 0;
-      height: 100%;
+    a {
+      text-decoration: none;
+      color: initial;
       width: 100%;
-    }
-
-    figure.cover {
-      margin: 0;
-      float: left;
       height: 100%;
-      max-width: 60%;
-      border-right: 1px solid hsl(0, 0%, 90%);
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
 
-      img {
+      figure {
+        margin: 15px;
+
+        img, .text-cover {
+          height: 215px;
+          max-width: 150px;
+          border: 1px solid hsl(0, 0%, 90%);
+        }
+
+        .text-cover {
+          background: hsl(0, 0%, 20%);
+          color: hsl(360, 100%, 100%);
+          padding: 5px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          font-family: 'Merriweather', serif;
+
+          h5, h6 {
+            margin: 5px 0;
+          }
+        }
+      }
+
+      .info {
         height: 100%;
-        width: 100%;
+        margin: 0;
+
+        .index {
+          background: hsl(0, 0%, 0%);
+          color: hsl(360, 100%, 100%);
+          width: 2em;
+          height: 2em;
+          font-size: 0.8em;
+          padding: 0.5em;
+          line-height: 1.1;
+          float: right;
+        }
+
+        .details {
+          clear: both;
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          justify-content: center;
+          padding: 1em;
+          font-family: 'Merriweather', serif;
+          font-size: 0.8em;
+          color: hsl(0, 0%, 40%);
+          text-align: right;
+        }
       }
     }
+  }
 
-    .info {
-      text-align: right;
-      font-size: 0.8em;
-      color: hsl(0, 0%, 40%);
-      padding: 0.8em;
-
-      .year {
-        padding-top: 0.5em;
-      }
+  @media only screen and (min-width: 650px) {
+    .book {
+      margin: 10px;
     }
   }
 </style>

--- a/app/javascript/components/books.vue
+++ b/app/javascript/components/books.vue
@@ -1,19 +1,18 @@
 <template>
   <section class="books">
-    <div class="no-books" v-if="this.bookCount === 0">
-      There are no books. 😞
-    </div>
-    <template v-else>
-      <div class="description">
+    <div class="description">
+      <p>
         <span class="emoji">💁🏻‍♀️💁🏽‍♂️</span>
-        The library has <strong>{{ this.bookCount }}</strong> of your recently added to-read books.
-        <div class="sort-controls">
-          <button @click="this.sortByRatingDesc">Highest rated first</button>
-          <button @click="this.sortByYearDesc">Most recently published first</button>
-        </div>
-      </div>
-      <book :bookObj="book" v-for="book in books" :key="book.isbn" />
-    </template>
+        We've found <strong>{{ this.bookCount }}</strong> of your recently added to-read books.
+      </p>
+    </div>
+    <div class="sort-controls">
+      <button @click="this.sortByRatingDesc">Highest rated first</button>
+      <button @click="this.sortByYearDesc">Most recently published first</button>
+    </div>
+    <div class="book-list">
+      <book :book="book" :index=index v-for="(book, index) in books" :key="book.isbn" />
+    </div>
   </section>
 </template>
 
@@ -46,67 +45,48 @@
 
 <style lang="scss" scoped>
   .books {
-    display: grid;
-    grid-template-columns: 100%;
-    grid-template-rows: auto;
-    grid-gap: 1em;
-    justify-items: center;
-    align-items: center;
-    padding: 3em 0;
+    max-width: 90vw;
+    margin: 2em auto;
+    font-family: 'Lato', sans-serif;
 
     .description {
-      padding: 0 2em 1em 2em;
-      font-family: 'Lato', sans-serif;
-      text-align: center;
-    }
+      font-size: 1.2em;
 
-    .sort-controls button {
-      margin: 0.5em 0.3em 0 0.3em;
-      font-family: inherit;
-      font-size: 0.8em;
-
-      &:hover {
-        cursor: pointer;
+      .emoji {
+        display: block;
       }
     }
 
-    .no-books {
-      margin-top: 20vh;
-    }
-  }
+    .sort-controls {
+      margin-bottom: 1.5em;
 
-  @media only screen and (min-width: 40em) {
-    .books {
-      grid-template-columns: 1fr 1fr;
-    }
-
-    .no-books {
-      grid-column: 1 / span 2;
-    }
-
-    .description {
-      padding-left: 2em;
-      grid-column: 1 / span 2;
-    }
-  }
-
-  @media only screen and (min-width: 65em) {
-    .books {
-      grid-template-columns: 1fr 1fr 1fr;
-
-      .description {
-        grid-column: 1 / span 1;
-        text-align: right;
-        align-self: start;
-
-        .emoji {
-          display: block;
-        }
+      button {
+        font-family: 'Lato', sans-serif;
+        font-size: 0.9em;
+        margin: 5px;
       }
     }
 
-    .no-books {
-      grid-column: 1 / span 3;
+    .book-list {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+  }
+
+  @media only screen and (min-width: 650px) {
+    .books {
+      max-width: 960px;
+
+      .description .emoji {
+        display: inline;
+      }
+
+      .book-list {
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
     }
   }
 </style>

--- a/app/javascript/components/loader.vue
+++ b/app/javascript/components/loader.vue
@@ -8,7 +8,7 @@
 <style scoped>
   .loading {
     color: #ffffff;
-    font-size: 1em;
+    font-size: 0.5em;
     margin: 100px auto;
     width: 1em;
     height: 1em;


### PR DESCRIPTION
Go back to a basic, grid-free layout: single-, 2- or 3-column depending on screen size. Will progressively enhance with grids and more content later.

* Each book now comes with an index.
* If a book doesn't have a proper cover image, make a text one with the book title and author.

![screen shot 2018-04-15 at 3 50 25 pm](https://user-images.githubusercontent.com/5506893/38779759-c59a989a-40c4-11e8-8d76-49df0f0f42d8.png)