### PR TITLE
Some book info layout tweaks

### DIFF
--- a/app/javascript/components/book.vue
+++ b/app/javascript/components/book.vue
@@ -97,6 +97,7 @@
       .info {
         height: 100%;
         margin: 0;
+        position: relative;
 
         .index {
           background: hsl(0, 0%, 0%);
@@ -106,11 +107,11 @@
           font-size: 0.8em;
           padding: 0.5em;
           line-height: 1.1;
-          float: right;
+          position: absolute;
+          right: 0;
         }
 
         .details {
-          clear: both;
           display: flex;
           flex-direction: column;
           height: 100%;

--- a/app/javascript/components/book.vue
+++ b/app/javascript/components/book.vue
@@ -108,7 +108,19 @@
           padding: 0.5em;
           line-height: 1.1;
           position: absolute;
-          right: 0;
+          right: 1em;
+
+          &:after {
+            content: '';
+            position: absolute;
+            width: 0;
+            height: 0;
+            top: 2em;
+            right: 0;
+            border-left: 1em solid transparent;
+            border-right: 1em solid transparent;
+            border-top: 1em solid hsl(0, 0%, 0%);
+          }
         }
 
         .details {


### PR DESCRIPTION
Two tweaks in this PR:

1) Fixed `.details` height so it doesn't look like this when tabbing through the books:
![screen shot 2018-04-15 at 6 58 53 pm](https://user-images.githubusercontent.com/5506893/38781775-584e3ef4-40e2-11e8-9047-bc0eac46ee46.png)

2) While I was at it, I tried giving the book index more of a badge look:
![screen shot 2018-04-15 at 7 21 18 pm](https://user-images.githubusercontent.com/5506893/38781794-8b23ce2a-40e2-11e8-8376-99ba1aab2be8.png)
